### PR TITLE
refactor: use any alias for empty interface

### DIFF
--- a/ae/log.go
+++ b/ae/log.go
@@ -46,17 +46,17 @@ func logctx(skip int) (file string, line int) {
 	return
 }
 
-func (log *Log) Debugf(format string, a ...interface{}) {
+func (log *Log) Debugf(format string, a ...any) {
 	log.Entry.Debugf(format, a...)
 }
 
-func (log *Log) Debugfd(format string, a ...interface{}) {
+func (log *Log) Debugfd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Entry.Debugf("%s:%d %s", file, line, fmt.Sprintf(format, a...))
 }
 
-func (log *Log) DebugJSON(v interface{}) {
+func (log *Log) DebugJSON(v any) {
 	if b, err := json.MarshalIndent(v, "", "\t"); err != nil {
 		log.Entry.Debugf("json.MarshalIndent(): err=%v", err)
 	} else {
@@ -64,31 +64,31 @@ func (log *Log) DebugJSON(v interface{}) {
 	}
 }
 
-func (log *Log) Infof(format string, a ...interface{}) {
+func (log *Log) Infof(format string, a ...any) {
 	log.Entry.Infof(format, a...)
 }
 
-func (log *Log) Infofd(format string, a ...interface{}) {
+func (log *Log) Infofd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Entry.Infof("%s:%d %s", file, line, fmt.Sprintf(format, a...))
 }
 
-func (log *Log) Warningf(format string, a ...interface{}) {
+func (log *Log) Warningf(format string, a ...any) {
 	log.Entry.Warningf(format, a...)
 }
 
-func (log *Log) Warningfd(format string, a ...interface{}) {
+func (log *Log) Warningfd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Entry.Warningf("%s:%d %s", file, line, fmt.Sprintf(format, a...))
 }
 
-func (log *Log) Errorf(format string, a ...interface{}) {
+func (log *Log) Errorf(format string, a ...any) {
 	log.Entry.Errorf(format, a...)
 }
 
-func (log *Log) Errorfd(format string, a ...interface{}) {
+func (log *Log) Errorfd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Entry.Errorf("%s:%d %s", file, line, fmt.Sprintf(format, a...))

--- a/compress.go
+++ b/compress.go
@@ -7,7 +7,7 @@ import (
 	msgpack "github.com/vmihailenco/msgpack/v5"
 )
 
-func Compress(data interface{}) []byte {
+func Compress(data any) []byte {
 	m, err := msgpack.Marshal(data)
 	if err != nil {
 		panic(err)
@@ -25,7 +25,7 @@ func Compress(data interface{}) []byte {
 	return b.Bytes()
 }
 
-func Decompress(enc []byte, out interface{}) {
+func Decompress(enc []byte, out any) {
 	if len(enc) == 0 {
 		return
 	}

--- a/err.go
+++ b/err.go
@@ -22,7 +22,7 @@ func (e UserError) Message() string {
 	return e.UserMessage
 }
 
-func UserErrorfc(err error, format string, a ...interface{}) error {
+func UserErrorfc(err error, format string, a ...any) error {
 	file, line := logctx(1)
 
 	return UserError{
@@ -31,7 +31,7 @@ func UserErrorfc(err error, format string, a ...interface{}) error {
 	}
 }
 
-func Errorfc(format string, a ...interface{}) error {
+func Errorfc(format string, a ...any) error {
 	file, line := logctx(1)
 
 	return fmt.Errorf("%s:%d %w", trim(file), line, fmt.Errorf(format, a...))

--- a/fixture/fixture.go
+++ b/fixture/fixture.go
@@ -45,7 +45,7 @@ func makeFixturePath(t *testing.T, extra string) string {
 // If 'data' is a string it gets written verbatim, otherwise it's json-encoded.
 //
 // The filename of the fixture is generated from the test name. To use multiple fixtures in one test see FixtureExtra()
-func Fixture(t *testing.T, data interface{}) {
+func Fixture(t *testing.T, data any) {
 	t.Helper()
 
 	FixtureExtra(t, "", data)
@@ -56,7 +56,7 @@ func Fixture(t *testing.T, data interface{}) {
 // If 'data' is a string it gets written verbatim, otherwise it's json-encoded.
 //
 // The filename of the fixture is generated from the test name with 'extra' appended.
-func FixtureExtra(t *testing.T, extra string, data interface{}) {
+func FixtureExtra(t *testing.T, extra string, data any) {
 	t.Helper()
 
 	// Write strings verbatim, otherwise json-encode.
@@ -104,7 +104,7 @@ func InputFixture(t *testing.T, filename string) []byte {
 }
 
 // InputFixtureJson returns the contents of a json fixture file, and unmarshals it
-func InputFixtureJson(t *testing.T, filename string, v interface{}) {
+func InputFixtureJson(t *testing.T, filename string, v any) {
 	t.Helper()
 
 	data := InputFixture(t, filename)

--- a/libpaddle/paddle.go
+++ b/libpaddle/paddle.go
@@ -111,7 +111,7 @@ func NewCheckoutClient(ctx context.Context, client *http.Client) *Client {
 
 // addOptions adds the parameters in opt as URL query parameters to s. opt
 // must be a struct whose fields may contain "url" tags.
-func addOptions(s string, opt interface{}) (string, error) {
+func addOptions(s string, opt any) (string, error) {
 	v := reflect.ValueOf(opt)
 	if v.Kind() == reflect.Ptr && v.IsNil() {
 		return s, nil
@@ -136,7 +136,7 @@ func addOptions(s string, opt interface{}) (string, error) {
 // Relative URLs should always be specified without a preceding slash. If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(method, urlStr string, body any) (*http.Request, error) {
 	if !strings.HasSuffix(c.baseURL.Path, "/") {
 		return nil, fmt.Errorf("baseURL must have a trailing slash, but %q does not", c.baseURL)
 	}
@@ -177,7 +177,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 //
 // The provided ctx must be non-nil. If it is canceled or times out,
 // ctx.Err() will be returned.
-func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*http.Response, error) {
+func (c *Client) Do(ctx context.Context, req *http.Request, v any) (*http.Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		// If we got an error, and the context has been canceled,

--- a/libpaddle/subscription_event.go
+++ b/libpaddle/subscription_event.go
@@ -154,7 +154,7 @@ func phpserialize(form url.Values) []byte {
 }
 
 // https://paddle.com/docs/reference-verifying-webhooks/
-func ValidatePayload(r *http.Request, pubkey *rsa.PublicKey) (interface{}, error) {
+func ValidatePayload(r *http.Request, pubkey *rsa.PublicKey) (any, error) {
 	payload := map[string]string{}
 
 	// Get the p_signature parameter and base64 decode it.

--- a/log.go
+++ b/log.go
@@ -8,13 +8,13 @@ import (
 
 var Debug = false
 
-func LogcDebugf(format string, a ...interface{}) {
+func LogcDebugf(format string, a ...any) {
 	if Debug {
 		log.Printf(format, a...)
 	}
 }
 
-func LogcDebugfd(format string, a ...interface{}) {
+func LogcDebugfd(format string, a ...any) {
 	if Debug {
 		file, line := logctx(1)
 
@@ -22,32 +22,32 @@ func LogcDebugfd(format string, a ...interface{}) {
 	}
 }
 
-func LogcInfof(format string, a ...interface{}) {
+func LogcInfof(format string, a ...any) {
 	log.Printf(format, a...)
 }
 
-func LogcInfofd(format string, a ...interface{}) {
+func LogcInfofd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Printf("%s:%d %s", file, line, fmt.Sprintf(format, a...))
 }
 
-func LogcErrorf(format string, a ...interface{}) {
+func LogcErrorf(format string, a ...any) {
 	log.Printf("ERROR: "+format, a...)
 }
 
-func LogcErrorfd(format string, a ...interface{}) {
+func LogcErrorfd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Printf("ERROR: %s:%d %s", file, line, fmt.Sprintf(format, a...))
 }
 
-func LogcFatalf(format string, a ...interface{}) {
+func LogcFatalf(format string, a ...any) {
 	log.Printf("FATAL: "+format, a...)
 	os.Exit(1)
 }
 
-func LogcFatalfd(format string, a ...interface{}) {
+func LogcFatalfd(format string, a ...any) {
 	file, line := logctx(1)
 
 	log.Printf("FATAL: %s:%d %s", file, line, fmt.Sprintf(format, a...))

--- a/misc.go
+++ b/misc.go
@@ -42,7 +42,7 @@ func RandEmail() string {
 	return md5Hash[:len(md5Hash)/2]
 }
 
-func Dump(path string, what interface{}) error {
+func Dump(path string, what any) error {
 	if b, err := json.MarshalIndent(what, "", "\t"); err != nil {
 		return Errorc(err)
 	} else if err := os.WriteFile(path, b, 0644); err != nil {

--- a/webhandler/respond.go
+++ b/webhandler/respond.go
@@ -7,7 +7,7 @@ import (
 	"github.com/akfaew/utils"
 )
 
-func WriteResponse(w http.ResponseWriter, data interface{}) error {
+func WriteResponse(w http.ResponseWriter, data any) error {
 	w.Header().Set("Content-Type", "application/json")
 	if data == nil {
 		// Write has other side effects, and we don't want to write "null".

--- a/webhandler/webhandler.go
+++ b/webhandler/webhandler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-var ErrorContextFunc func(message, meditation string) interface{} = nil
+var ErrorContextFunc func(message, meditation string) any = nil
 
 type WebHandler func(http.ResponseWriter, *http.Request) *WebError
 
@@ -29,7 +29,7 @@ type WebError struct {
 	Message string // for the user
 }
 
-func WebErrorf(code int, err error, format string, v ...interface{}) *WebError {
+func WebErrorf(code int, err error, format string, v ...any) *WebError {
 	return &WebError{
 		Code:    code,
 		Error:   err,
@@ -45,7 +45,7 @@ func WebErrorInternal(err error) *WebError {
 	}
 }
 
-func WebErrorInternalf(err error, format string, v ...interface{}) *WebError {
+func WebErrorInternalf(err error, format string, v ...any) *WebError {
 	return &WebError{
 		Code:    http.StatusInternalServerError,
 		Error:   err,
@@ -101,7 +101,7 @@ func (fn WebHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		buf := new(bytes.Buffer)
-		var vars interface{}
+		var vars any
 		if ErrorContextFunc != nil {
 			vars = ErrorContextFunc(e.Message, m)
 		}
@@ -129,7 +129,7 @@ func WebHandle(r *mux.Router, method string, path string, handler func(w http.Re
 }
 
 // Executor uses webContext() to obtain a list of variables to pass to the underlying html template.
-func (tmpl *WebTemplate) Executor(webContext func(http.ResponseWriter, *http.Request, *WebTemplate) (interface{}, *WebError)) func(http.ResponseWriter, *http.Request) *WebError {
+func (tmpl *WebTemplate) Executor(webContext func(http.ResponseWriter, *http.Request, *WebTemplate) (any, *WebError)) func(http.ResponseWriter, *http.Request) *WebError {
 	return func(w http.ResponseWriter, r *http.Request) *WebError {
 		// Get the web context
 		vars, weberr := webContext(w, r, tmpl)

--- a/webhandler/webhandler_test.go
+++ b/webhandler/webhandler_test.go
@@ -15,7 +15,7 @@ var nolog = ParseTemplate("base.html", "simple.html")
 var redirect = ParseTemplate("base.html", "simple.html")
 var nobase = ParseTemplate("nobase.html")
 
-func webContext(w http.ResponseWriter, r *http.Request, tmpl *WebTemplate) (interface{}, *WebError) {
+func webContext(w http.ResponseWriter, r *http.Request, tmpl *WebTemplate) (any, *WebError) {
 	if tmpl == failure {
 		return nil, WebErrorf(http.StatusInternalServerError, fmt.Errorf("ooups"), "User error")
 	} else if tmpl == nolog {
@@ -31,7 +31,7 @@ func webContext(w http.ResponseWriter, r *http.Request, tmpl *WebTemplate) (inte
 	}, nil
 }
 
-func errorContext(message, meditation string) interface{} {
+func errorContext(message, meditation string) any {
 	return struct {
 		Message string
 	}{


### PR DESCRIPTION
## Summary
- replace `interface{}` with `any` throughout the library and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68909d43187883228c4d2f931796b7d7