### PR TITLE
chore: update Go to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/akfaew/utils
 
-go 1.22
+go 1.24
 
 require (
 	github.com/google/go-querystring v1.1.0


### PR DESCRIPTION
## Summary
- update module to Go 1.24

## Testing
- `golangci-lint run` *(fails: errcheck and staticcheck issues)*
- `go test ./...`
- `go mod tidy` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_68909d43187883228c4d2f931796b7d7