### PR TITLE
refactor: use filepath for directory trimming

### DIFF
--- a/ae/log.go
+++ b/ae/log.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -29,7 +30,7 @@ func NewLog(ctx context.Context) *Log {
 func init() {
 	_, path, _, _ := runtime.Caller(1)
 
-	trimprefix = path[:strings.LastIndex(path, "/")+1]
+	trimprefix = filepath.Dir(path) + string(filepath.Separator)
 
 	formatter := stackdriver.GAEStandardFormatter(
 		stackdriver.WithProjectID(os.Getenv("GOOGLE_CLOUD_PROJECT")),

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -13,7 +14,7 @@ func Init(path string) {
 		_, path, _, _ = runtime.Caller(1)
 	}
 
-	trimprefix = path[:strings.LastIndex(path, "/")+1]
+	trimprefix = filepath.Dir(path) + string(filepath.Separator)
 }
 
 func trim(path string) string {


### PR DESCRIPTION
## Summary
- replace string slicing with filepath.Dir when deriving directory prefixes

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890a9fdcf98832281e7ab437a871f7c