### PR TITLE
Drop redundant Slash helper

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -10,14 +10,8 @@ import (
 	"math/rand/v2"
 	"os"
 	"slices"
-	"strings"
 	"time"
 )
-
-func Slash(text string) (string, string) {
-	before, after, _ := strings.Cut(text, "/")
-	return before, after
-}
 
 // A simple sum for naming fixture files in tests, e.g. based on an URL.
 func Crc32(str string) string {

--- a/misc_test.go
+++ b/misc_test.go
@@ -9,28 +9,6 @@ import (
 	"github.com/akfaew/utils/fixture"
 )
 
-func TestSlash(t *testing.T) {
-	tests := []struct {
-		input string
-		ret1  string
-		ret2  string
-	}{
-		{"", "", ""},
-		{"test", "test", ""},
-		{"test/", "test", ""},
-		{"test///", "test", "//"},
-		{"test/case", "test", "case"},
-		{"test/case/a/b/c", "test", "case/a/b/c"},
-		{"/case/a/b/c", "", "case/a/b/c"},
-	}
-
-	for _, tc := range tests {
-		ret1, ret2 := Slash(tc.input)
-		require.Equal(t, ret1, tc.ret1)
-		require.Equal(t, ret2, tc.ret2)
-	}
-}
-
 func TestRandEmail(t *testing.T) {
 	val := RandEmail()
 	require.Len(t, val, 16)


### PR DESCRIPTION
## Summary
- remove `Slash` helper; callers can use `strings.Cut`
- retain `RootCause` convenience wrapper for now

## Testing
- `make setup` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `make test` *(fails: goanalysis_metalinter: inspect: failed to load package logrus: could not load export data)*

------
https://chatgpt.com/codex/tasks/task_e_68918b515a5883229eaaf50338c5a4eb