### PR TITLE
Validate traceparent parsing and trace propagation

### DIFF
--- a/ae/stackdriver-gae-logrus-plugin/formatter.go
+++ b/ae/stackdriver-gae-logrus-plugin/formatter.go
@@ -93,7 +93,7 @@ func (f *Formatter) Format(e *logrus.Entry) ([]byte, error) {
 	xctc := xctc.XCTC(e.Context)
 	if xctc != "" {
 		trace, err := utils.ParseTraceParent(string(xctc))
-		if err != nil {
+		if err == nil {
 			ee.Trace = fmt.Sprintf("projects/%s/traces/%s", f.projectID, trace.TraceID)
 			ee.SpanID = trace.ParentID
 		}

--- a/traceparent.go
+++ b/traceparent.go
@@ -37,16 +37,26 @@ func ParseTraceParent(header string) (*TraceParent, error) {
 	if err != nil {
 		return nil, Errorfc("invalid version: %w", err)
 	}
-	if string(traceID) == "00000000000000000000000000000000" {
+
+	if _, err := hex.DecodeString(traceID); err != nil {
+		return nil, Errorfc("invalid trace-id: %w", err)
+	}
+	if strings.ToLower(traceID) == "00000000000000000000000000000000" {
 		return nil, Errorfc("trace-id all zero")
 	}
-	if string(parentID) == "0000000000000000" {
+
+	if _, err := hex.DecodeString(parentID); err != nil {
+		return nil, Errorfc("invalid parent-id: %w", err)
+	}
+	if strings.ToLower(parentID) == "0000000000000000" {
 		return nil, Errorfc("parent-id all zero")
 	}
+
 	flags, err := hex.DecodeString(flagsStr)
 	if err != nil {
 		return nil, Errorfc("invalid trace-flags: %w", err)
 	}
+
 	return &TraceParent{
 		Version:    ver[0],
 		TraceID:    strings.ToLower(traceID),

--- a/traceparent_test.go
+++ b/traceparent_test.go
@@ -43,6 +43,16 @@ func TestParseTraceParent(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name:      "Invalid hex in trace-id",
+			input:     "00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-00f067aa0ba902b7-01",
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid hex in parent-id",
+			input:     "00-4bf92f3577b34da6a3ce929d0e0e4736-zzzzzzzzzzzzzzzz-01",
+			shouldErr: true,
+		},
+		{
 			name:      "Invalid field length",
 			input:     "00-1234-00f067aa0ba902b7-01",
 			shouldErr: true,


### PR DESCRIPTION
## Summary
- Validate trace and parent IDs when parsing W3C traceparent headers
- Use trace and span IDs only when traceparent parsing succeeds
- Test invalid hex characters in traceparent IDs

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895ecaf59748322b91c1918e1e6499a