### PR TITLE
Simplify Errorc wrappers and expand tests

### DIFF
--- a/err.go
+++ b/err.go
@@ -26,7 +26,7 @@ func UserErrorfc(err error, format string, a ...any) error {
 	file, line := logctx(1)
 
 	return UserError{
-		Err:         fmt.Errorf("%s:%d %w", trim(file), line, err),
+		Err:         fmt.Errorf("%s:%d %w", file, line, err),
 		UserMessage: fmt.Sprintf(format, a...),
 	}
 }
@@ -34,7 +34,7 @@ func UserErrorfc(err error, format string, a ...any) error {
 func Errorfc(format string, a ...any) error {
 	file, line := logctx(1)
 
-	return fmt.Errorf("%s:%d %w", trim(file), line, fmt.Errorf(format, a...))
+	return fmt.Errorf("%s:%d %w", file, line, fmt.Errorf(format, a...))
 }
 
 func Errorc(err error) error {
@@ -43,7 +43,7 @@ func Errorc(err error) error {
 	}
 	file, line := logctx(1)
 
-	return fmt.Errorf("%s:%d %w", trim(file), line, err)
+	return fmt.Errorf("%s:%d %w", file, line, err)
 }
 
 func RootCause(err error) error {

--- a/err_test.go
+++ b/err_test.go
@@ -19,6 +19,12 @@ func TestErrorc(t *testing.T) {
 		require.Regexp(t, `utils/err_test.go:\d+ oups`, err.Error())
 	})
 
+	t.Run("format", func(t *testing.T) {
+		err := Errorfc("formatted %d", 7)
+		t.Logf("err.Error() = %s", err.Error())
+		require.Regexp(t, `utils/err_test.go:\d+ formatted 7`, err.Error())
+	})
+
 	t.Run("is", func(t *testing.T) {
 		err := Errorc(os.ErrNotExist)
 		require.True(t, errors.Is(err, os.ErrNotExist))
@@ -26,6 +32,7 @@ func TestErrorc(t *testing.T) {
 
 	t.Run("nice", func(t *testing.T) {
 		err := UserErrorfc(os.ErrNotExist, "Something bad happened %d", 5)
+		require.Regexp(t, `utils/err_test.go:\d+ file does not exist`, err.Error())
 		require.True(t, errors.Is(err, os.ErrNotExist))
 	})
 }


### PR DESCRIPTION
### Summary
- Simplify Errorc, Errorfc, and UserErrorfc by relying on already-trimmed paths
- Add tests exercising Errorfc formatting and UserErrorfc path handling

### Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6899a1506e3883229417774dae4e4fd7